### PR TITLE
Fix for conda conflicts

### DIFF
--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -1,5 +1,6 @@
 @echo off
 cd /d %~dp0
+SET CONDA_SHLVL=
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
 IF EXIST CONDA GOTO APP

--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -1,5 +1,6 @@
 @echo off
 cd /d %~dp0
+SET CONDA_SHLVL=
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
 umamba create --no-shortcuts -r conda -n windows -f environment.yaml -y


### PR DESCRIPTION
Recently discovered while troubleshooting a user who could not run KoboldAI, micromamba does not execute if CONDA_SHLVL is present in someone's environment variables. Installations who used conda init before will run in this issue and can then get conflicts where the correct dependencies are not loaded.

With this workaround we remove this variable before running the runtime scripts, forcing it to correctly set all the variables for the micromamba environment. Because this is self contained to the batch scripts it should be safe towards the other conda installations, as the overrides are limited to the command line window and intentional since we want to use our runtime instead.