### PR TITLE
More universal runtime

### DIFF
--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -1,14 +1,4 @@
 @echo off
 cd /d %~dp0
-SET CONDA_SHLVL=
-
-Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
-IF EXIST CONDA GOTO APP
-
-:INSTALL
-call update-runtime
-
-:APP
-call conda\condabin\activate.bat windows
-python bridge.py %*
-pause
+call runtime python bridge.py %*
+%0

--- a/horde-bridge.sh
+++ b/horde-bridge.sh
@@ -1,1 +1,1 @@
-./runtime.sh python bridge.sh
+./runtime.sh python bridge.py

--- a/horde-bridge.sh
+++ b/horde-bridge.sh
@@ -1,5 +1,1 @@
-#!/bin/bash
-if [ ! -f "conda/envs/linux/bin/python" ]; then
-./update-runtime.sh
-fi
-bin/micromamba run -r conda -n linux python bridge.py $*
+./runtime.sh python bridge.sh

--- a/runtime.cmd
+++ b/runtime.cmd
@@ -1,0 +1,13 @@
+@echo off
+cd /d %~dp0
+
+Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
+IF EXIST CONDA GOTO APP
+
+:INSTALL
+call update-runtime
+
+:APP
+call conda\condabin\activate.bat windows
+%*
+IF [%1] == [] TITLE Runtime Command Prompt && cmd /k

--- a/runtime.sh
+++ b/runtime.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ ! -f "conda/envs/linux/bin/python" ]; then
+./update-runtime.sh
+fi
+bin/micromamba run -r conda -n linux $*


### PR DESCRIPTION
In the spirit of this being a branch others can build on I made my runtime fully universal, others can easily add call runtime in front of their batch command to easily use the runtime for that command. This means you can now skip all the hassle of the python management in your scripts.

See the horde-bridge.cmd as an example, which is now a simple "call runtime python bridge.py"

This will also allow other projects to adopt the runtime with little to no effort, as long as they have a compatible environments.yaml file present the rest is automatic.