### PR TITLE
mo-di-diffusion model and CreativeML OpenRAIL-M

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This repository provides python libraries for running Stable Diffusion
 
-Sample use: 
+Sample use:
 
 ```python
 from nataili.model_manager import ModelManager
@@ -10,7 +10,7 @@ from nataili.util.cache import torch_gc
 # The model manager loads and unloads the SD models and has features to download them or find their location
 model_manager = ModelManager()
 model_manager.init()
-# The model to use for the generation. 
+# The model to use for the generation.
 model = "stable_diffusion"
 success = model_manager.load_model(model)
 if success:
@@ -48,3 +48,6 @@ The bridge has experimental inpainting support via Diffusers library. This **can
 **run `update-runtime.cmd` or `update-runtime.sh` as dependencies have been updated**
 
 To set your worker to serve inpainting, add "stable_diffusion_inpainting" into your bridgeData's models_to_load list. The rest will be handled automatically. Workers without this model will not receive inpainting requests. Workers with **just** this model will **not** receive any requests **other** than inpainting! This will be fixed as soon as Diffusers are supported fully.
+
+## Model Usage
+Many models in this project use the CreativeML OpenRAIL License.  [Please read the full license here.](https://huggingface.co/spaces/CompVis/stable-diffusion-license)

--- a/bridgeData_template.py
+++ b/bridgeData_template.py
@@ -43,7 +43,7 @@ models_to_load = [
     # "Spier-Verse Diffusion",
     # "Elden Ring Diffusion",
     # "Robo-Diffusion",
-    # "Modern Disney Diffusion",
+    # "mo-di-diffusion",
 
     # "stable_diffusion_inpainting", # Enable this to allow inpainting/outpainting. Careful of trying to enable this in tandem with other models if you have 8G or less VRAM!
 ]

--- a/db.json
+++ b/db.json
@@ -30,7 +30,7 @@
       ]
     },
     "available": false
-  },  
+  },
   "stable_diffusion_1.4": {
     "name": "stable_diffusion_1.4",
     "type": "ckpt",
@@ -219,6 +219,36 @@
           "file_name": "trinart.ckpt",
           "file_path": "models/custom",
           "file_url": "https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step95000.ckpt"
+        }
+      ]
+    },
+    "available": false
+  },
+  "mo-di-diffusion": {
+    "name": "mo-di-diffusion",
+    "type": "ckpt",
+    "description": "Popular animation studio styled generations.",
+    "version": "1",
+    "style": "dreambooth",
+    "nsfw": false,
+    "download_all": true,
+    "requires": [
+      "clip-vit-large-patch14"
+    ],
+    "config": {
+      "files": [
+        {
+          "path": "models/custom/mo-di-diffusion.ckpt"
+        },
+        {
+          "path": "configs/stable-diffusion/v1-inference.yaml"
+        }
+      ],
+      "download": [
+        {
+          "file_name": "mo-di-diffusion.ckpt",
+          "file_path": "models/custom",
+          "file_url": "https://huggingface.co/nitrosocke/mo-di-diffusion/resolve/main/moDi-v1-pruned.ckpt"
         }
       ]
     },

--- a/db.json
+++ b/db.json
@@ -238,7 +238,8 @@
     "config": {
       "files": [
         {
-          "path": "models/custom/mo-di-diffusion.ckpt"
+          "path": "models/custom/mo-di-diffusion.ckpt",
+          "md5sum": "393f79603e5cab05307670d0f71a5193"
         },
         {
           "path": "configs/stable-diffusion/v1-inference.yaml"


### PR DESCRIPTION
Adding the mo-di-diffusion model. 
The mo-di-diffusion model and trinart model are licensed under the CreativeML OpenRAIL License which specifies among other things:
"You may re-distribute the weights and use the model commercially and/or as a service. If you do, please be aware you have to include the same use restrictions as the ones in the license and share a copy of the CreativeML OpenRAIL-M to all your users (please read the license entirely and carefully) [Please read the full license here](https://huggingface.co/spaces/CompVis/stable-diffusion-license)" - https://huggingface.co/spaces/CompVis/stable-diffusion-license

I added a small bit of text to the read me which should satisfy the condition of the users being aware of the license. 