### PR TITLE
New inpainting based on runway implementation

### DIFF
--- a/configs/stable-diffusion/v1-inpainting-inference.yaml
+++ b/configs/stable-diffusion/v1-inpainting-inference.yaml
@@ -1,0 +1,70 @@
+model:
+  base_learning_rate: 7.5e-05
+  target: ldm.models.diffusion.ddpm.LatentInpaintDiffusion
+  params:
+    linear_start: 0.00085
+    linear_end: 0.0120
+    num_timesteps_cond: 1
+    log_every_t: 200
+    timesteps: 1000
+    first_stage_key: "jpg"
+    cond_stage_key: "txt"
+    image_size: 64
+    channels: 4
+    cond_stage_trainable: false   # Note: different from the one we trained before
+    conditioning_key: hybrid   # important
+    monitor: val/loss_simple_ema
+    scale_factor: 0.18215
+    finetune_keys: null
+
+    scheduler_config: # 10000 warmup steps
+      target: ldm.lr_scheduler.LambdaLinearScheduler
+      params:
+        warm_up_steps: [ 2500 ] # NOTE for resuming. use 10000 if starting from scratch
+        cycle_lengths: [ 10000000000000 ] # incredibly large number to prevent corner cases
+        f_start: [ 1.e-6 ]
+        f_max: [ 1. ]
+        f_min: [ 1. ]
+
+    unet_config:
+      target: ldm.modules.diffusionmodules.openaimodel.UNetModel
+      params:
+        image_size: 32 # unused
+        in_channels: 9  # 4 data + 4 downscaled image + 1 mask
+        out_channels: 4
+        model_channels: 320
+        attention_resolutions: [ 4, 2, 1 ]
+        num_res_blocks: 2
+        channel_mult: [ 1, 2, 4, 4 ]
+        num_heads: 8
+        use_spatial_transformer: True
+        transformer_depth: 1
+        context_dim: 768
+        use_checkpoint: True
+        legacy: False
+
+    first_stage_config:
+      target: ldm.models.autoencoder.AutoencoderKL
+      params:
+        embed_dim: 4
+        monitor: val/rec_loss
+        ddconfig:
+          double_z: true
+          z_channels: 4
+          resolution: 256
+          in_channels: 3
+          out_ch: 3
+          ch: 128
+          ch_mult:
+          - 1
+          - 2
+          - 4
+          - 4
+          num_res_blocks: 2
+          attn_resolutions: []
+          dropout: 0.0
+        lossconfig:
+          target: torch.nn.Identity
+
+    cond_stage_config:
+      target: ldm.modules.encoders.modules.FrozenCLIPEmbedder

--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -17,6 +17,7 @@ from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
 from pytorch_lightning.utilities.distributed import rank_zero_only
+from omegaconf import ListConfig
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma
@@ -1248,6 +1249,25 @@ class LatentDiffusion(DDPM):
 
 
     @torch.no_grad()
+    def get_unconditional_conditioning(self, batch_size, null_label=None):
+        if null_label is not None:
+            xc = null_label
+            if isinstance(xc, ListConfig):
+                xc = list(xc)
+            if isinstance(xc, dict) or isinstance(xc, list):
+                c = self.get_learned_conditioning(xc)
+            else:
+                if hasattr(xc, "to"):
+                    xc = xc.to(self.device)
+                c = self.get_learned_conditioning(xc)
+        else:
+            # todo: get null label from cond_stage_model
+            raise NotImplementedError()
+        c = repeat(c, "1 ... -> b ...", b=batch_size).to(self.device)
+        return c
+
+
+    @torch.no_grad()
     def log_images(self, batch, N=8, n_row=4, sample=True, ddim_steps=200, ddim_eta=1., return_keys=None,
                    quantize_denoised=True, inpaint=True, plot_denoise_rows=False, plot_progressive_rows=True,
                    plot_diffusion_rows=True, **kwargs):
@@ -1443,3 +1463,59 @@ class Layout2ImgDiffusion(LatentDiffusion):
         cond_img = torch.stack(bbox_imgs, dim=0)
         logs['bbox_image'] = cond_img
         return logs
+
+
+class LatentInpaintDiffusion(LatentDiffusion):
+    def __init__(
+        self,
+        concat_keys=("mask", "masked_image"),
+        masked_image_key="masked_image",
+        finetune_keys=None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.masked_image_key = masked_image_key
+        assert self.masked_image_key in concat_keys
+        self.concat_keys = concat_keys
+
+
+    @torch.no_grad()
+    def get_input(
+        self, batch, k, cond_key=None, bs=None, return_first_stage_outputs=False
+    ):
+        # note: restricted to non-trainable encoders currently
+        assert (
+            not self.cond_stage_trainable
+        ), "trainable cond stages not yet supported for inpainting"
+        z, c, x, xrec, xc = super().get_input(
+            batch,
+            self.first_stage_key,
+            return_first_stage_outputs=True,
+            force_c_encode=True,
+            return_original_cond=True,
+            bs=bs,
+        )
+
+        assert exists(self.concat_keys)
+        c_cat = list()
+        for ck in self.concat_keys:
+            cc = (
+                rearrange(batch[ck], "b h w c -> b c h w")
+                .to(memory_format=torch.contiguous_format)
+                .float()
+            )
+            if bs is not None:
+                cc = cc[:bs]
+                cc = cc.to(self.device)
+            bchw = z.shape
+            if ck != self.masked_image_key:
+                cc = torch.nn.functional.interpolate(cc, size=bchw[-2:])
+            else:
+                cc = self.get_first_stage_encoding(self.encode_first_stage(cc))
+            c_cat.append(cc)
+        c_cat = torch.cat(c_cat, dim=1)
+        all_conds = {"c_concat": [c_cat], "c_crossattn": [c]}
+        if return_first_stage_outputs:
+            return z, all_conds, x, xrec, xc
+        return z, all_conds

--- a/ldm/modules/diffusionmodules/openaimodel.py
+++ b/ldm/modules/diffusionmodules/openaimodel.py
@@ -958,4 +958,3 @@ class EncoderUNetModel(nn.Module):
         else:
             h = h.type(x.dtype)
             return self.out(h)
-

--- a/nataili/inference/inpainting.py
+++ b/nataili/inference/inpainting.py
@@ -1,0 +1,287 @@
+import os
+import re
+import sys
+import numpy as np
+import torch
+from PIL import Image
+import PIL.ImageOps
+from omegaconf import OmegaConf
+from einops import repeat
+from ldm.util import instantiate_from_config
+from ldm.models.diffusion.ddim import DDIMSampler
+from slugify import slugify
+
+from nataili.util import logger
+from nataili.util.cache import torch_gc
+from nataili.util.get_next_sequence_number import get_next_sequence_number
+from nataili.util.save_sample import save_sample
+from nataili.util.seed_to_int import seed_to_int
+
+
+class inpainting:
+    def __init__(
+        self,
+        device,
+        output_dir,
+        save_extension="jpg",
+        output_file_path=False,
+        load_concepts=False,
+        concepts_dir=None,
+        verify_input=True,
+        auto_cast=True,
+        filter_nsfw=False,
+    ):
+        self.output_dir = output_dir
+        self.output_file_path = output_file_path
+        self.save_extension = save_extension
+        self.load_concepts = load_concepts
+        self.concepts_dir = concepts_dir
+        self.verify_input = verify_input
+        self.auto_cast = auto_cast
+        self.device = device
+        self.comments = []
+        self.output_images = []
+        self.info = ""
+        self.stats = ""
+        self.images = []
+        self.filter_nsfw = filter_nsfw
+
+
+    def initialize_model(
+        self,
+        config,
+        ckpt
+    ):
+        config = OmegaConf.load(config)
+        model = instantiate_from_config(config.model)
+        model.load_state_dict(torch.load(ckpt)["state_dict"], strict=False)
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        self.model = model.to(device)
+        return
+
+
+    def resize_image(self, resize_mode, im, width, height):
+        LANCZOS = PIL.Image.Resampling.LANCZOS if hasattr(PIL.Image, "Resampling") else PIL.Image.LANCZOS
+        if resize_mode == "resize":
+            res = im.resize((width, height), resample=LANCZOS)
+        elif resize_mode == "crop":
+            ratio = width / height
+            src_ratio = im.width / im.height
+
+            src_w = width if ratio > src_ratio else im.width * height // im.height
+            src_h = height if ratio <= src_ratio else im.height * width // im.width
+
+            resized = im.resize((src_w, src_h), resample=LANCZOS)
+            res = PIL.Image.new("RGBA", (width, height))
+            res.paste(resized, box=(width // 2 - src_w // 2, height // 2 - src_h // 2))
+        else:
+            ratio = width / height
+            src_ratio = im.width / im.height
+
+            src_w = width if ratio < src_ratio else im.width * height // im.height
+            src_h = height if ratio >= src_ratio else im.height * width // im.width
+
+            resized = im.resize((src_w, src_h), resample=LANCZOS)
+            res = PIL.Image.new("RGBA", (width, height))
+            res.paste(resized, box=(width // 2 - src_w // 2, height // 2 - src_h // 2))
+
+            if ratio < src_ratio:
+                fill_height = height // 2 - src_h // 2
+                res.paste(
+                    resized.resize((width, fill_height), box=(0, 0, width, 0)),
+                    box=(0, 0),
+                )
+                res.paste(
+                    resized.resize(
+                        (width, fill_height),
+                        box=(0, resized.height, width, resized.height),
+                    ),
+                    box=(0, fill_height + src_h),
+                )
+            elif ratio > src_ratio:
+                fill_width = width // 2 - src_w // 2
+                res.paste(
+                    resized.resize((fill_width, height), box=(0, 0, 0, height)),
+                    box=(0, 0),
+                )
+                res.paste(
+                    resized.resize(
+                        (fill_width, height),
+                        box=(resized.width, 0, resized.width, height),
+                    ),
+                    box=(fill_width + src_w, 0),
+                )
+
+        return res
+
+
+    def make_batch_sd(
+        self,
+        image,
+        mask,
+        txt,
+        device,
+        num_samples=1
+    ):
+        image = np.array(image.convert("RGB"))
+        image = image[None].transpose(0,3,1,2)
+        image = torch.from_numpy(image).to(dtype=torch.float32)/127.5-1.0
+
+        mask = np.array(mask.convert("L"))
+        mask = mask.astype(np.float32)/255.0
+        mask = mask[None,None]
+        mask[mask < 0.5] = 0
+        mask[mask >= 0.5] = 1
+        mask = torch.from_numpy(mask)
+
+        masked_image = image * (mask < 0.5)
+
+        batch = {
+            "image": repeat(image.to(device=device), "1 ... -> n ...", n=num_samples),
+            "txt": num_samples * [txt],
+            "mask": repeat(mask.to(device=device), "1 ... -> n ...", n=num_samples),
+            "masked_image": repeat(masked_image.to(device=device), "1 ... -> n ...", n=num_samples),
+        }
+
+        return batch
+
+    def generate(
+        self,
+        prompt: str,
+        inpaint_img=None,
+        inpaint_mask=None,
+        ddim_steps=50,
+        n_iter=1,
+        batch_size=1,
+        cfg_scale=7.5,
+        seed=None,
+        height=512,
+        width=512,
+        save_individual_images: bool = True,
+    ):
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        sampler = DDIMSampler(self.model)
+
+        inpaint_img = self.resize_image("resize", inpaint_img, width, height)
+
+        # mask information has been transferred in the Alpha channel of the inpaint image
+        logger.debug(inpaint_mask)
+        if inpaint_mask is None:
+            try:
+                red, green, blue, alpha = inpaint_img.split()
+            except ValueError:
+                raise Exception("inpainting image doesn't have an alpha channel.")
+
+            inpaint_mask = alpha
+            inpaint_mask = PIL.ImageOps.invert(inpaint_mask)
+        else:
+            inpaint_mask = self.resize_image("resize", inpaint_mask, width, height)
+
+        seed = seed_to_int(seed)
+        prng = np.random.RandomState(seed)
+        start_code = prng.randn(n_iter, 4, height//8, width//8)
+        start_code = torch.from_numpy(start_code).to(device=device, dtype=torch.float32)
+
+        if self.load_concepts and self.concepts_dir is not None:
+            prompt_tokens = re.findall("<([a-zA-Z0-9-]+)>", prompt)
+            if prompt_tokens:
+                self.process_prompt_tokens(prompt_tokens)
+
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        sample_path = os.path.join(self.output_dir, "samples")
+        os.makedirs(sample_path, exist_ok=True)
+
+        all_prompts = batch_size * [prompt]
+        all_seeds = [seed + x for x in range(len(all_prompts))]
+
+        torch_gc()
+
+        with torch.no_grad(), torch.autocast("cuda"):
+            for n in range(batch_size):
+                print(f"Iteration: {n+1}/{batch_size}")
+
+                prompt = all_prompts[n]
+                seed = all_seeds[n]
+                print("prompt: " + prompt + ", seed: " + str(seed))
+
+                batch = self.make_batch_sd(inpaint_img, inpaint_mask, txt=prompt, device=device, num_samples=n_iter)
+                c = self.model.cond_stage_model.encode(batch["txt"])
+                c_cat = list()
+
+                for ck in self.model.concat_keys:
+                    cc = batch[ck].float()
+
+                    if ck != self.model.masked_image_key:
+                        bchw = [n_iter, 4, height//8, width//8]
+                        cc = torch.nn.functional.interpolate(cc, size=bchw[-2:])
+                    else:
+                        cc = self.model.get_first_stage_encoding(self.model.encode_first_stage(cc))
+
+                    c_cat.append(cc)
+
+                c_cat = torch.cat(c_cat, dim=1)
+
+                # cond
+                cond={"c_concat": [c_cat], "c_crossattn": [c]}
+
+                # uncond cond
+                uc_cross = self.model.get_unconditional_conditioning(n_iter, "")
+                uc_full = {"c_concat": [c_cat], "c_crossattn": [uc_cross]}
+
+                shape = [self.model.channels, height//8, width//8]
+
+                samples_cfg, intermediates = sampler.sample(
+                    ddim_steps,
+                    n_iter,
+                    shape,
+                    cond,
+                    verbose=False,
+                    eta=1.0,
+                    unconditional_guidance_scale=cfg_scale,
+                    unconditional_conditioning=uc_full,
+                    x_T=start_code,
+                )
+
+                x_samples_ddim = self.model.decode_first_stage(samples_cfg)
+                result = torch.clamp((x_samples_ddim+1.0)/2.0, min=0.0, max=1.0)
+                result = result.cpu().numpy().transpose(0,2,3,1)
+                result = result*255
+
+                x_samples = [Image.fromarray(img.astype(np.uint8)) for img in result]
+
+                for i, x_sample in enumerate(x_samples):
+                    image_dict = {"seed": seed, "image": x_sample}
+                    self.images.append(image_dict)
+                    
+                    if save_individual_images:
+                        sanitized_prompt = slugify(prompt)
+                        sample_path_i = sample_path
+                        base_count = get_next_sequence_number(sample_path_i)
+                        full_path = os.path.join(os.getcwd(), sample_path)
+                        filename = f"{base_count:05}-{ddim_steps}_{seed}_{sanitized_prompt}"[: 200 - len(full_path)]
+
+                        path = os.path.join(sample_path, filename + "." + self.save_extension)
+                        success = save_sample(x_sample, filename, sample_path_i, self.save_extension)
+
+                        if success:
+                            if self.output_file_path:
+                                self.output_images.append(path)
+                            else:
+                                self.output_images.append(x_sample)
+                        else:
+                            return
+
+        self.info = f"""
+                {prompt}
+                Steps: {ddim_steps}, CFG scale: {cfg_scale}, Seed: {seed}
+                """.strip()
+        self.stats = """
+                """
+
+        for comment in self.comments:
+            self.info += "\n\n" + comment
+
+        torch_gc()
+
+        return

--- a/test_inpainting_new.py
+++ b/test_inpainting_new.py
@@ -1,0 +1,16 @@
+from PIL import Image
+from nataili.inference.inpainting import inpainting
+from nataili import disable_xformers
+
+config = "configs/stable-diffusion/v1-inpainting-inference.yaml"
+ckpt = "models/sd-v1-5-inpainting.ckpt"
+original = Image.open("./inpaint_original.png")
+mask = Image.open("./inpaint_mask.png")
+prompt = "a robot sitting on a bench"
+
+disable_xformers.toggle(True)
+generator = inpainting("cuda", "output_dir")
+generator.initialize_model(config, ckpt)
+generator.generate(prompt, original, mask)
+image = generator.images[0]["image"]
+image.save("robot_sitting_on_a_bench.png", format="PNG")


### PR DESCRIPTION
The currently used inpainting based on the diffusers inpainting pipeline works good in general. But one main problem is, that not only the part which should be changed by inpainting is changed, but the whole image. According to my tests and reports from other users, the runway implementation, on which this PR is based, seems to solve that problem mainly. This PR creates also the file test_inpainting_new.py, so you can check this yourself. This implementation uses the sd1.5 inpainting ckpt too.

**Comments**
1. As I'm not sure, where the secret sauce of the runway implementation is exactly, I didn't try to add inpainting to inference/compvis.py. Instead, I created the new file inference/inpainting.py. Imo the code used from runway shouldn't be touched. Otherwise there is a risk, that the inpainting quality worsens.
2. Currently inpainting.py doesn't use the model manager. Instead, it is assumed, that the ckpt file has been downloaded before manually. The function initialize_model is used for initialization. Both should of course be moved to the model manager. As you do know the manager much better than me, I think it will be a pretty easy task for you to do this. I would recommend to use exactly the code from initialize_model in model_manager bcs there is a chance, there is also some secret sauce here.
3. Currently nsfw disabling is not handled. I guess, this can also be added easily in model manager.
4. I did disable xformers as I got several errors when it was enabled. I guess the reason was, that I didn't compile xformers. So, please test if everything works with xformers enabled.
5. Three ldm files have been changed: ddpm, ddim and openaimodel. I hope these changes don't affect image generation with other models. So, it could be a good idea, to make a quick test to make sure, this is really true.
6. Currently it is logged pretty much during generation. It seems to be a kind of verbose mode. I try to find a way to disable that.