### PR TITLE
Number of improvements to the main loop, improving performance:

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -122,14 +122,17 @@ def bridge(this_model_manager, this_bridge_data):
                                     logger.error("Job failed with exception, {}", job.exception())
                                     logger.exception(job.exception())
                                 run_count += 1
-                                logger.debug(f"Job finished successfully in {runtime:.3f}s (Total Completed: {run_count})")
+                                logger.debug(
+                                    f"Job finished successfully in {runtime:.3f}s (Total Completed: {run_count})"
+                                )
                                 running_jobs.remove((job, start_time))
                                 continue
 
                             # check if any job has run for more than 180 seconds
                             if job.running() and runtime > 180:
                                 logger.warning(
-                                    f"Restarting all jobs, as a job was running for more than 180 seconds: {runtime:.3f}s"
+                                    "Restarting all jobs, as a job was running "
+                                    f"for more than 180 seconds: {runtime:.3f}s"
                                 )
                                 for (inner_job, inner_start_time) in running_jobs:  # Sometimes it's already removed
                                     running_jobs.remove((inner_job, inner_start_time))
@@ -154,6 +157,7 @@ def bridge(this_model_manager, this_bridge_data):
         job.cancel()
     logger.info("Shutting down bridge - Done")
 
+
 # Helper functions
 def pop_job(this_model_manager, this_bridge_data):
     new_job = HordeJob(this_model_manager, this_bridge_data)
@@ -163,6 +167,7 @@ def pop_job(this_model_manager, this_bridge_data):
         logger.debug("Got a new job from the horde for model: {}", job_model)
         return new_job, pop
     return None, None
+
 
 if __name__ == "__main__":
     set_logger_verbosity(args.verbosity)

--- a/bridge.py
+++ b/bridge.py
@@ -96,6 +96,7 @@ def bridge(this_model_manager, this_bridge_data):
                                 logger.debug("Added a new job from the horde to the queue, for model: {}", job_model)
                                 waiting_jobs.append((new_job, pop))
                             else:
+                                time.sleep(0.5)  # Don't hammer the server if there's no generations waiting
                                 del new_job
 
                         while len(running_jobs) < this_bridge_data.max_threads:
@@ -122,8 +123,8 @@ def bridge(this_model_manager, this_bridge_data):
                                 logger.warning(
                                     f"Restarting all jobs, as a job was running for more than 180 seconds: {runtime:.3f}s"
                                 )
-                                for inner_job in running_jobs:  # Sometimes it's already removed
-                                    running_jobs.remove(inner_job)
+                                for (inner_job, inner_start_time) in running_jobs:  # Sometimes it's already removed
+                                    running_jobs.remove((inner_job, inner_start_time))
                                     job.cancel()
                                 executor.shutdown(wait=False)
                                 break

--- a/bridgeData_template.py
+++ b/bridgeData_template.py
@@ -18,6 +18,9 @@ max_power = 8
 # Expected limit per VRAM size: <6 VMAM: 1, <=8 VRAM: 2, <=12 VRAM:3, <=14 VRAM: 4
 # But remember that the speed of your gens will also be affected for each parallel job
 max_threads = 1
+# We will keep this many requests in the queue so we can start working as soon as a thread is available
+# Recommended to keep at 1
+queue_size = 1
 # Set this to false, if you do not want your worker to receive requests for NSFW generations
 nsfw = True
 # Set this to True if you want your worker to censor NSFW generations. This will only be active is horde_nsfw == False

--- a/bridgeData_template.py
+++ b/bridgeData_template.py
@@ -19,8 +19,8 @@ max_power = 8
 # But remember that the speed of your gens will also be affected for each parallel job
 max_threads = 1
 # We will keep this many requests in the queue so we can start working as soon as a thread is available
-# Recommended to keep at 1
-queue_size = 1
+# Recommended to keep no higher than 1
+queue_size = 0
 # Set this to false, if you do not want your worker to receive requests for NSFW generations
 nsfw = True
 # Set this to True if you want your worker to censor NSFW generations. This will only be active is horde_nsfw == False

--- a/nataili/util/logger.py
+++ b/nataili/util/logger.py
@@ -89,10 +89,10 @@ def test_logger():
 
 
 logfmt = (
-    "<level>{level: <10}</level> | <green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <10}</level> | <green>{time:YYYY-MM-DD HH:mm:ss.SSSSSS}</green> | "
     "<green>{name}</green>:<green>{function}</green>:<green>{line}</green> - <level>{message}</level>"
 )
-genfmt = "<level>{level: <10}</level> @ <green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{message}</level>"
+genfmt = "<level>{level: <10}</level> @ <green>{time:YYYY-MM-DD HH:mm:ss.SSSSSS}</green> | <level>{message}</level>"
 initfmt = "<magenta>INIT      </magenta> | <level>{extra[status]: <11}</level> | <magenta>{message}</magenta>"
 msgfmt = "<level>{level: <10}</level> | <level>{message}</level>"
 

--- a/worker/argparser.py
+++ b/worker/argparser.py
@@ -50,6 +50,12 @@ arg_parser.add_argument(
     help="How much power this instance has to generate pictures. Min: 2",
 )
 arg_parser.add_argument(
+    "--queue_size",
+    type=int,
+    required=False,
+    help="How many requests to keep in the queue. Min: 1",
+)
+arg_parser.add_argument(
     "--sfw",
     action="store_true",
     required=False,

--- a/worker/argparser.py
+++ b/worker/argparser.py
@@ -53,7 +53,7 @@ arg_parser.add_argument(
     "--queue_size",
     type=int,
     required=False,
-    help="How many requests to keep in the queue. Min: 1",
+    help="How many requests to keep in the queue. Min: 0",
 )
 arg_parser.add_argument(
     "--sfw",

--- a/worker/bridge_data.py
+++ b/worker/bridge_data.py
@@ -34,7 +34,7 @@ class BridgeData:
         self.priority_usernames = list(filter(lambda a: a, os.environ.get("HORDE_PRIORITY_USERNAMES", "").split(",")))
         self.max_power = int(os.environ.get("HORDE_MAX_POWER", 8))
         self.max_threads = int(os.environ.get("HORDE_MAX_THREADS", 1))
-        self.queue_size = int(os.environ.get("HORDE_QUEUE_SIZE", 1))
+        self.queue_size = int(os.environ.get("HORDE_QUEUE_SIZE", 0))
         self.nsfw = os.environ.get("HORDE_NSFW", "true") == "true"
         self.censor_nsfw = os.environ.get("HORDE_CENSOR", "false") == "true"
         self.blacklist = list(filter(lambda a: a, os.environ.get("HORDE_BLACKLIST", "").split(",")))

--- a/worker/bridge_data.py
+++ b/worker/bridge_data.py
@@ -34,6 +34,7 @@ class BridgeData:
         self.priority_usernames = list(filter(lambda a: a, os.environ.get("HORDE_PRIORITY_USERNAMES", "").split(",")))
         self.max_power = int(os.environ.get("HORDE_MAX_POWER", 8))
         self.max_threads = int(os.environ.get("HORDE_MAX_THREADS", 1))
+        self.queue_size = int(os.environ.get("HORDE_QUEUE_SIZE", 1))
         self.nsfw = os.environ.get("HORDE_NSFW", "true") == "true"
         self.censor_nsfw = os.environ.get("HORDE_CENSOR", "false") == "true"
         self.blacklist = list(filter(lambda a: a, os.environ.get("HORDE_BLACKLIST", "").split(",")))
@@ -114,6 +115,10 @@ class BridgeData:
             except AttributeError:
                 pass
             try:
+                self.queue_size = bd.queue_size
+            except AttributeError:
+                pass
+            try:
                 self.dynamic_models = bd.dynamic_models
             except AttributeError:
                 pass
@@ -143,6 +148,8 @@ class BridgeData:
             self.max_power = args.max_power
         if args.max_power:
             self.max_threads = args.max_threads
+        if args.queue_size:
+            self.queue_size = args.queue_size
         if args.model:
             self.model = [args.model]
         if args.sfw:

--- a/worker/job.py
+++ b/worker/job.py
@@ -15,7 +15,6 @@ from PIL import Image, UnidentifiedImageError
 from nataili.inference.compvis import CompVis
 from nataili.inference.diffusers.inpainting import inpainting
 from nataili.util import logger
-from nataili.util.cache import torch_gc
 from worker.enums import JobStatus
 from worker.post_process import post_process
 from worker.stats import bridge_stats

--- a/worker/job.py
+++ b/worker/job.py
@@ -335,8 +335,6 @@ class HordeJob:
             logger.debug("Starting generation...")
             generator.generate(**gen_payload)
             logger.debug("Finished generation...")
-            torch_gc()  # TODO: Can we live without this? Adds 200ms to each generation
-            logger.debug("gc done...")
         except RuntimeError as err:
             stack_payload = gen_payload
             stack_payload["request_type"] = req_type

--- a/worker/job.py
+++ b/worker/job.py
@@ -335,7 +335,7 @@ class HordeJob:
             logger.debug("Starting generation...")
             generator.generate(**gen_payload)
             logger.debug("Finished generation...")
-            torch_gc() ## TODO: Can we live without this? Adds 200ms to each generation
+            torch_gc()  # TODO: Can we live without this? Adds 200ms to each generation
             logger.debug("gc done...")
         except RuntimeError as err:
             stack_payload = gen_payload


### PR DESCRIPTION
- job.exception() blocks until the job is done. Because of this, the main loop would always wait until all jobs were finished before continuing

- Because of this, the job > 180s code path wasn't reachable
  This path still had some bugs that were fixed

- Added a queue in front of the running jobs. This way, we can already retrieve the next job while the previous one is still running, hiding the job-pop latency

- log timestamps with microsecond precision + added debug logging for performance tuning

GPU's are actually not great at running multiple workloads at once; On a 3090 I see ~20% total throughput drop as soon as the second job starts. With these optimisations, it should be possible to run the worker with max_threads = 1 for optimal performance.

Even for higher thread counts, the job.exception block prevented these threads from getting the highest utilisation of the GPU, so even in that case performance should be significantly better.