### PR TITLE
fix for models_to_load when dynamic_models=False

### DIFF
--- a/worker/bridge_data.py
+++ b/worker/bridge_data.py
@@ -78,10 +78,6 @@ class BridgeData:
             self.horde_url = bd.horde_url
             self.priority_usernames = bd.priority_usernames
             self.max_power = bd.max_power
-            if not self.dynamic_models:
-                self.model_names = bd.models_to_load
-            else:
-                self.predefined_models = bd.models_to_load
             try:
                 self.nsfw = bd.nsfw
             except AttributeError:
@@ -134,6 +130,10 @@ class BridgeData:
                 self.models_to_skip = bd.models_to_skip
             except AttributeError:
                 pass
+            if not self.dynamic_models:
+                self.model_names = bd.models_to_load
+            else:
+                self.predefined_models = bd.models_to_load
         except (ImportError, AttributeError) as err:
             logger.warning("bridgeData.py could not be loaded. Using defaults with anonymous account - {}", err)
         if args.api_key:


### PR DESCRIPTION
Hi, this PR addresses an issue I ran into with disabling dynamic models.

`worker/bridge_data.py` checks `self.dynamic_models` to decide how `models_to_load` should be used, but this check happens before `dynamic_models` is loaded from `bridgeData.py`, so it's actually checking the hard-coded default value (always `True`) instead of the user's value.

As a result, if you disable dynamic models and try to load just one model (such as `stable_diffusion_inpainting`) it will load `stable_diffusion` instead by default, and only load your preferred model later.

This PR moves the check to after `dynamic_models` is loaded.