### PR TITLE
voodoo diffusers

### DIFF
--- a/nataili/inference/diffusers/inpainting.py
+++ b/nataili/inference/diffusers/inpainting.py
@@ -12,13 +12,14 @@ from nataili.util.cache import torch_gc
 from nataili.util.get_next_sequence_number import get_next_sequence_number
 from nataili.util.save_sample import save_sample
 from nataili.util.seed_to_int import seed_to_int
-
 from nataili import disable_voodoo
+
 try:
     from nataili.util.voodoo import load_diffusers_pipeline_from_plasma, performance
 except ModuleNotFoundError as e:
     if not disable_voodoo.active:
         raise e
+
 
 class inpainting:
     def __init__(
@@ -204,7 +205,7 @@ class inpainting:
 
                     if safety_checker:
                         self.pipe.safety_checker = safety_checker
-                
+
                 for i, x_sample in enumerate(x_samples):
                     image_dict = {"seed": seed, "image": x_sample}
 

--- a/nataili/inference/diffusers/inpainting.py
+++ b/nataili/inference/diffusers/inpainting.py
@@ -107,6 +107,7 @@ class inpainting:
 
         return res
 
+    @performance
     def generate(
         self,
         prompt: str,

--- a/nataili/inference/diffusers/inpainting.py
+++ b/nataili/inference/diffusers/inpainting.py
@@ -7,12 +7,12 @@ import PIL.ImageOps
 import torch
 from slugify import slugify
 
+from nataili import disable_voodoo
 from nataili.util import logger
 from nataili.util.cache import torch_gc
 from nataili.util.get_next_sequence_number import get_next_sequence_number
 from nataili.util.save_sample import save_sample
 from nataili.util.seed_to_int import seed_to_int
-from nataili import disable_voodoo
 
 try:
     from nataili.util.voodoo import load_diffusers_pipeline_from_plasma, performance

--- a/nataili/inference/diffusers/inpainting.py
+++ b/nataili/inference/diffusers/inpainting.py
@@ -27,6 +27,7 @@ class inpainting:
         verify_input=True,
         auto_cast=True,
         filter_nsfw=False,
+        disable_voodoo=False,
     ):
         self.output_dir = output_dir
         self.output_file_path = output_file_path

--- a/nataili/inference/diffusers/inpainting.py
+++ b/nataili/inference/diffusers/inpainting.py
@@ -50,6 +50,7 @@ class inpainting:
         self.stats = ""
         self.images = []
         self.filter_nsfw = filter_nsfw
+        self.disable_voodoo = disable_voodoo
 
     def resize_image(self, resize_mode, im, width, height):
         LANCZOS = PIL.Image.Resampling.LANCZOS if hasattr(PIL.Image, "Resampling") else PIL.Image.LANCZOS

--- a/nataili/model_manager.py
+++ b/nataili/model_manager.py
@@ -426,6 +426,7 @@ class ModelManager:
             torch_dtype=torch.float16 if precision == "half" else None,
             use_auth_token=self.models[model_name]["hf_auth"],
         )
+        pipe.enable_attention_slicing()
 
         if not self.disable_voodoo:
             logger.debug(f"Doing voodoo on {model_name}")

--- a/nataili/model_manager.py
+++ b/nataili/model_manager.py
@@ -24,7 +24,7 @@ from ldm.util import instantiate_from_config
 from nataili.inference.aitemplate.ait_pipeline import StableDiffusionAITPipeline
 
 try:
-    from nataili.util.voodoo import init_ait_module, push_model_to_plasma
+    from nataili.util.voodoo import init_ait_module, push_model_to_plasma, push_diffusers_pipeline_to_plasma
 except ModuleNotFoundError as e:
     from nataili import disable_voodoo
 
@@ -416,18 +416,26 @@ class ModelManager:
         data_lists = self.load_data_lists(data_path=data_path)
         return {"model": model, "device": device, "preprocess": preprocess, "data_lists": data_lists}
 
-    def load_diffuser(self, model_name=""):
+    def load_diffuser(self, model_name="", precision="half", gpu_id=0):
         model_path = self.models[model_name]["hf_path"]
+        device = torch.device(f"cuda:{gpu_id}")
+
         pipe = StableDiffusionInpaintPipeline.from_pretrained(
             model_path,
-            revision="fp16",
-            torch_dtype=torch.float16,
+            revision="fp16" if precision == "half" else None,
+            torch_dtype=torch.float16 if precision == "half" else None,
             use_auth_token=self.models[model_name]["hf_auth"],
         )
 
-        pipe.enable_attention_slicing()
-        pipe.to("cuda")
-        return {"model": pipe, "device": "cuda"}
+        if not self.disable_voodoo:
+            logger.debug(f"Doing voodoo on {model_name}")
+            pipe = push_diffusers_pipeline_to_plasma(pipe)
+        else:
+            pipe.to(device)
+
+        torch_gc()
+
+        return {"model": pipe, "device": device}
 
     def load_ait(self):
         self.loaded_models["ait"] = {}

--- a/nataili/model_manager.py
+++ b/nataili/model_manager.py
@@ -24,7 +24,7 @@ from ldm.util import instantiate_from_config
 from nataili.inference.aitemplate.ait_pipeline import StableDiffusionAITPipeline
 
 try:
-    from nataili.util.voodoo import init_ait_module, push_model_to_plasma, push_diffusers_pipeline_to_plasma
+    from nataili.util.voodoo import init_ait_module, push_diffusers_pipeline_to_plasma, push_model_to_plasma
 except ModuleNotFoundError as e:
     from nataili import disable_voodoo
 

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -73,12 +73,30 @@ def load_from_plasma(ref, device="cuda"):
     yield skeleton
     torch.cuda.empty_cache()
 
-
 def push_model_to_plasma(model: torch.nn.Module) -> ray.ObjectRef:
     ref = ray.put(extract_tensors(model))
 
     return ref
 
+@contextlib.contextmanager
+def load_diffusers_pipeline_from_plasma(ref, device="cuda"):
+    pipe, modules = ray.get(ref)
+    for name, weights in modules.items():
+        replace_tensors(getattr(pipe, name), weights, device=device)
+    pipe.to(device)
+    yield pipe
+    torch.cuda.empty_cache()
+
+def push_diffusers_pipeline_to_plasma(pipe) -> ray.ObjectRef:
+    modules = {}
+    components = pipe.components
+    for name, component in components.items():
+        if isinstance(component, torch.nn.Module):
+            skeleton, weights = extract_tensors(component)
+            setattr(pipe, name, skeleton)
+            modules[name] = weights
+    ref = ray.put((pipe, modules))
+    return ref
 
 def init_ait_module(
     model_name,

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -73,10 +73,12 @@ def load_from_plasma(ref, device="cuda"):
     yield skeleton
     torch.cuda.empty_cache()
 
+
 def push_model_to_plasma(model: torch.nn.Module) -> ray.ObjectRef:
     ref = ray.put(extract_tensors(model))
 
     return ref
+
 
 @contextlib.contextmanager
 def load_diffusers_pipeline_from_plasma(ref, device="cuda"):
@@ -86,6 +88,7 @@ def load_diffusers_pipeline_from_plasma(ref, device="cuda"):
     pipe.to(device)
     yield pipe
     torch.cuda.empty_cache()
+
 
 def push_diffusers_pipeline_to_plasma(pipe) -> ray.ObjectRef:
     modules = {}
@@ -97,6 +100,7 @@ def push_diffusers_pipeline_to_plasma(pipe) -> ray.ObjectRef:
             modules[name] = weights
     ref = ray.put((pipe, modules))
     return ref
+
 
 def init_ait_module(
     model_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ omegaconf
 Jinja2
 
 #diffusers==0.4.1
-diffusers==0.6.0
+diffusers==0.11.1
 
 # Img2text
 ftfy

--- a/worker/job.py
+++ b/worker/job.py
@@ -307,7 +307,7 @@ class HordeJob:
                 disable_voodoo=self.bridge_data.disable_voodoo.active,
             )
         else:
-            if model != 'stable_diffusion_inpainting':
+            if model != "stable_diffusion_inpainting":
                 # We remove the base64 from the prompt to avoid flooding the output on the error
                 if len(pop.get("source_image", "")) > 10:
                     pop["source_image"] = len(pop.get("source_image", ""))

--- a/worker/job.py
+++ b/worker/job.py
@@ -307,6 +307,18 @@ class HordeJob:
                 disable_voodoo=self.bridge_data.disable_voodoo.active,
             )
         else:
+            if model != 'stable_diffusion_inpainting':
+                # We remove the base64 from the prompt to avoid flooding the output on the error
+                if len(pop.get("source_image", "")) > 10:
+                    pop["source_image"] = len(pop.get("source_image", ""))
+                if len(pop.get("source_mask", "")) > 10:
+                    pop["source_mask"] = len(pop.get("source_mask", ""))
+                logger.error(
+                    "Received an inpainting request for a non-inpainting model. This shouldn't happen. "
+                    f"Inform the developer. Current payload {pop}"
+                )
+                self.status = JobStatus.FAULTED
+                return
             # These variables do not exist in the outpainting implementation
             if "save_grid" in gen_payload:
                 del gen_payload["save_grid"]

--- a/worker/job.py
+++ b/worker/job.py
@@ -331,6 +331,7 @@ class HordeJob:
                 self.model_manager.loaded_models[model]["device"],
                 "bridge_generations",
                 filter_nsfw=use_nsfw_censor,
+                disable_voodoo=self.bridge_data.disable_voodoo.active,
             )
         try:
             logger.debug("Starting generation...")


### PR DESCRIPTION
Hi,

This draft PR is an attempt to get voodoo working with the diffusers inpainting pipeline.

It works on my single thread worker with voodoo enabled, a Tesla T4 and 16GB system RAM - but needs more testing to ensure it works as expected and doesn't break anything on other systems and configurations.

Unlike Compvis-style models which are just PyTorch modules, diffusers "pipelines" are Python classes that load multiple PyTorch modules into class properties. So the PR runs the `extract_tensors` and `replace_tensors` functions on each module separately.

Since this approach makes use of a recently added diffusers feature (the `components` property, to list the pipeline's modules), the PR also bumps diffusers to the latest version. As far as I can tell, the newer version doesn't break anything.

Upgrading diffusers probably has the side effect of enabling xformers for inpainting, since diffusers recently added support for it.

Let me know what you think and if there are issues that need fixed.